### PR TITLE
Deprecation of io/ioutil

### DIFF
--- a/main.go
+++ b/main.go
@@ -2,7 +2,7 @@ package main
 
 import (
 	"fmt"
-	"io/ioutil"
+	"os"
 	"time"
 
 	"github.com/hrittikhere/feedposter/extractor"
@@ -12,7 +12,7 @@ import (
 
 func main() {
 
-	file, err := ioutil.ReadFile("feed.yaml")
+	file, err := os.ReadFile("feed.yaml")
 	if err != nil {
 		fmt.Println("Error reading config file: ", err)
 	}


### PR DESCRIPTION
The io/ioutil package has turned out to be a poorly defined and hard to understand collection of things. All functionality provided by the package has been moved to other packages. 

`ReadFile => os.ReadFile`

More Details here: https://go.dev/doc/go1.16#ioutil